### PR TITLE
dependenices: remove default dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,12 +161,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
 name = "function_name"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,22 +180,6 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "hashbrown"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
-
-[[package]]
-name = "indexmap"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -311,7 +289,6 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
- "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -369,15 +346,6 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
-dependencies = [
- "toml_edit",
 ]
 
 [[package]]
@@ -486,36 +454,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.23.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "toml_parser",
- "winnow",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
-dependencies = [
- "winnow",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,15 +544,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "0.7.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ homepage = "https://qubip.eu"
 regen = ["dep:bindgen", "dep:pkg-config"]
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { version = "1.0", default-features = false }
 bitflags = "2.13"
 function_name = "0.3"
-libc = "0.2"
+libc = { version = "0.2", default-features = false }
 log = "0.4"
-num-traits = "0.2"
-num_enum = "0.7"
-zeroize = "1.9"
+num-traits = { version = "0.2", default-features = false }
+num_enum = { version = "0.7", default-features = false }
+zeroize = { version = "1.9", default-features = false }
 
 [dev-dependencies]
 env_logger = "0.11"

--- a/src/upcalls.rs
+++ b/src/upcalls.rs
@@ -33,7 +33,7 @@ pub mod traits {
     pub(crate) use ::function_name::named;
     use anyhow::anyhow;
     use std::sync::OnceLock;
-    use zeroize::{Zeroize, Zeroizing};
+    use zeroize::Zeroize;
     pub trait CoreUpcaller {
         fn fn_from_core_dispatch(&self, id: u32) -> Option<unsafe extern "C" fn()>;
 
@@ -74,7 +74,7 @@ pub mod traits {
 
             // We use a mutable Vec to buffer reads, so we can do big reads on the heap and minimize calls
             // we might want to tweak the capacity depending on what size data we're usually using it for
-            let mut buffer: Zeroizing<Vec<u8>> = Zeroizing::new(vec![42; 8 * 1024 * 1024]);
+            let mut buffer: Vec<u8> = vec![42; 8 * 1024 * 1024];
             let mut bytes_read: usize = 0;
 
             let mut ret_buffer: Vec<u8> = Vec::new();
@@ -114,12 +114,14 @@ pub mod traits {
                         "Reached {cnt:} upcalls to BIO_read_ex => stopping due to too many attempts"
                     );
                     ret_buffer.zeroize();
+                    buffer.zeroize();
                     return Err(anyhow::anyhow!(
                         "Underlying upcall to BIO_read_ex called too many times"
                     ));
                 }
                 ret_buffer.extend_from_slice(&buffer[0..bytes_read]);
             }
+            buffer.zeroize();
             Ok(ret_buffer.into_boxed_slice())
         }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

I use this crate alongside my other crates that are no_std in the same workspace. This crate enables
std features on dependenceis, some of which are utilized by my no_std crates, which breaks the compilation.

It looks like these features are not necessary for this crate to function anyway. So I disabled them. In one place I had to remove `Zeroizing`, but I
think it's fine since you zeroize another variable in that function (`ret_buffer`) manually.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

No behavior changes.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
